### PR TITLE
chore: fix wrong configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'ref/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
typo on `if: github.ref == 'ref/heads/main'` should be `if: github.ref == 'refs/heads/main'` ref with an 's' refs